### PR TITLE
Fix does not work --qtype #3

### DIFF
--- a/modules/xt_dns.c
+++ b/modules/xt_dns.c
@@ -129,7 +129,7 @@ static bool dns_mt(const struct sk_buff *skb, struct xt_action_param *par,
             return false;
         }
         if ((dnsinfo->setflags & XT_DNS_FLAG_QTYPE) &&
-            !FWINVDNS((qtype == dnsinfo->qtype), XT_DNS_FLAG_QTYPE)) {
+            !FWINVDNS((qtype == htons(dnsinfo->qtype)), XT_DNS_FLAG_QTYPE)) {
             DEBUG_PRINT("not match qtype");
             return false;
         }


### PR DESCRIPTION
qtypeのマッチができていなかった問題。
修正後マッチすることを確認

[root@centos7 mimuret]# iptables --list -v
Chain INPUT (policy ACCEPT 47 packets, 3261 bytes)
 pkts bytes target     prot opt in     out     source               destination
    1    59            all  --  any    any     anywhere             anywhere            dns --qtype ANY
    1    59            all  --  any    any     anywhere             anywhere            dns --qtype PTR
    1    59            all  --  any    any     anywhere             anywhere            dns --qtype A
