### PR TITLE
use $(src) instead of ${PWD} to point current build directory

### DIFF
--- a/modules/Makefile
+++ b/modules/Makefile
@@ -1,6 +1,6 @@
 # -*- Makefile
 obj-m := xt_dns.o
-ccflags-y := -O3 -I${PWD}/../include
+ccflags-y := -O3 -I$(src)/../include
 DEPMOD=/sbin/depmod
 INSTALL=/usr/bin/install -c
 KERNEL_RELEASE=`uname -r`


### PR DESCRIPTION
According to Section 4.3 of [Building External Modules](https://www.kernel.org/doc/Documentation/kbuild/modules.txt), $(src) is used to point the source file location.
This change addresses build failure on Debian GNU/Linux 8.0 (jessie).
I haven't tested it on RHEL clones.
